### PR TITLE
bugfix/1-fix-signup-link

### DIFF
--- a/lib/screens/sign_in.dart
+++ b/lib/screens/sign_in.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'package:othego_project/screens/admin_dashboard.dart';
 import 'package:othego_project/widgets/custom_scaffold.dart';
 import 'homepage.dart';
+import 'sign_up.dart';
 
 class SignIn extends StatefulWidget {
   const SignIn({super.key});
@@ -232,20 +233,30 @@ class _SignInState extends State<SignIn> {
                       const SizedBox(height: 20),
                       Center(
                         child: GestureDetector(
-                            onTap: () {},
-                            child: RichText(
-                              text: const TextSpan(
-                                  text: "Don't have an account? ",
-                                  style: TextStyle(color: Colors.black),
-                                  children: [
-                                    TextSpan(
-                                      text: "Sign Up",
-                                      style: TextStyle(
-                                        color: Colors.blue,
-                                      ),
-                                    ),
-                                  ]),
-                            )),
+                          onTap: () {
+                            // Navigate to the SignUp page when the user taps on "Sign Up"
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (context) =>
+                                      const SignUp()), // Navigate to the SignUp page
+                            );
+                          },
+                          child: RichText(
+                            text: const TextSpan(
+                              text: "Don't have an account? ",
+                              style: TextStyle(color: Colors.black),
+                              children: [
+                                TextSpan(
+                                  text: "Sign Up",
+                                  style: TextStyle(
+                                    color: Colors.blue,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
                       )
                     ],
                   ),


### PR DESCRIPTION
### Problem
The "Sign Up" link on the sign-in page was not responding when users tapped, causing the user from accessing the sign-up form in the sign-up page especially the new user.

### Solution
The link is updated and redirected to page when users tapping the link then navigate the user.

### Testing
- Checked using virtual devices provided by Android Studio
<img width="699" height="57" alt="Screenshot 2025-12-11 160406" src="https://github.com/user-attachments/assets/b6aace44-855b-4c5f-af10-264ac97d5207" />

